### PR TITLE
CN-X Add Fragment to react global dep

### DIFF
--- a/config/global-dependencies/react.ts
+++ b/config/global-dependencies/react.ts
@@ -1,5 +1,5 @@
-import type ReactType from "react";
-const react: typeof ReactType = window["react"];
+import type ReactType from 'react';
+const react: typeof ReactType = window['react'];
 export const {
   version,
   useState,
@@ -12,6 +12,7 @@ export const {
   createFactory,
   createRef,
   forwardRef,
+  Fragment,
   isValidElement,
   lazy,
   memo,


### PR DESCRIPTION

There was a warning in the Stripe extension repo due to Fragment missing. Used by the loader coming from the component library.