### PR TITLE
Allow CI to pass when there are no tests

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Check types
         run: npm run check-types
       - name: Run tests
-        run: npm run test
+        run: npm run test -- --passWithNoTests


### PR DESCRIPTION

CI currently fails if there are no tests defined. Not all apps will need tests so it shouldn't be a requirement.