### PR TITLE
CN-X Old controls fix

### DIFF
--- a/src/hello-world/components/hello-world.tsx
+++ b/src/hello-world/components/hello-world.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { WithControls, ControlButton, WithStyles, Script } from 'smart-builder-sdk';
+import { ControlButton, Script, WithControls, WithStyles } from 'smart-builder-sdk';
 import { ComponentProps, WithStylesProps } from 'unbounce-smart-builder-sdk-types';
 
 import { ChangeFirstNameModal } from './change-first-name-modal';
@@ -65,7 +65,7 @@ export default WithStyles(
         </ControlButton>
       ),
       Panel,
-      type: 'subtoolbar',
+      type: 'dropdown',
     },
   ]),
   'styles', // The object key where styles are applied from the Schema

--- a/src/hello-world/index.tsx
+++ b/src/hello-world/index.tsx
@@ -1,15 +1,11 @@
-import React from 'react';
 import { component, Schema } from 'ub-shared';
 
 import HelloWorld from './components/hello-world';
 import { migrations } from './migrations';
 
 const schema = Schema.object({
-  firstName: Schema.string().noControls(),
-  lastName: Schema.string().groupControls({
-    icon: <span>LN</span>,
-    label: 'Last Name',
-  }),
+  firstName: Schema.string(),
+  lastName: Schema.string(),
   styles: Schema.newStyle({
     textAlign: {
       layoutSpecific: true,

--- a/src/hello-world/index.tsx
+++ b/src/hello-world/index.tsx
@@ -16,7 +16,7 @@ const schema = Schema.object({
 export const Component = component({
   componentTypeId: 'helloWorld', // This is the id for your component in our system, must be camelCase. It is used to reference the component in places like templates
   displayName: 'HelloWorld',
-  tags: ['newControls', 'swappable'],
+  tags: ['newControls', 'swappable', 'isFullWidth'],
   schema,
   Component: HelloWorld,
   version: migrations.length,


### PR DESCRIPTION
## What is this change?

- Removes use of old controls
- Adds `isFullWidth` tag to sample component so that the text align controls actually do something
- Changes control to be a dropdown rather than a subtoolbar

<img width="400" alt="image" src="https://user-images.githubusercontent.com/20562946/188989275-7a6a11fd-6048-449d-a2e4-32e115c6ece2.png">




